### PR TITLE
Use fast-xml-parser over xq

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -43,6 +43,31 @@ module.exports =
 /************************************************************************/
 /******/ ({
 
+/***/ 66:
+/***/ (function(module) {
+
+"use strict";
+
+
+module.exports = function(tagname, parent, val) {
+  this.tagname = tagname;
+  this.parent = parent;
+  this.child = {}; //child tags
+  this.attrsMap = {}; //attributes map
+  this.val = val; //text only
+  this.addChild = function(child) {
+    if (Array.isArray(this.child[child.tagname])) {
+      //already presents
+      this.child[child.tagname].push(child);
+    } else {
+      this.child[child.tagname] = [child];
+    }
+  };
+};
+
+
+/***/ }),
+
 /***/ 87:
 /***/ (function(module) {
 
@@ -54,6 +79,708 @@ module.exports = require("os");
 /***/ (function(module) {
 
 module.exports = require("child_process");
+
+/***/ }),
+
+/***/ 170:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+
+const util = __webpack_require__(343);
+const buildOptions = __webpack_require__(343).buildOptions;
+const xmlNode = __webpack_require__(66);
+const TagType = {OPENING: 1, CLOSING: 2, SELF: 3, CDATA: 4};
+const regx =
+  '<((!\\[CDATA\\[([\\s\\S]*?)(]]>))|((NAME:)?(NAME))([^>]*)>|((\\/)(NAME)\\s*>))([^<]*)'
+  .replace(/NAME/g, util.nameRegexp);
+
+//const tagsRegx = new RegExp("<(\\/?[\\w:\\-\._]+)([^>]*)>(\\s*"+cdataRegx+")*([^<]+)?","g");
+//const tagsRegx = new RegExp("<(\\/?)((\\w*:)?([\\w:\\-\._]+))([^>]*)>([^<]*)("+cdataRegx+"([^<]*))*([^<]+)?","g");
+
+//polyfill
+if (!Number.parseInt && window.parseInt) {
+  Number.parseInt = window.parseInt;
+}
+if (!Number.parseFloat && window.parseFloat) {
+  Number.parseFloat = window.parseFloat;
+}
+
+const defaultOptions = {
+  attributeNamePrefix: '@_',
+  attrNodeName: false,
+  textNodeName: '#text',
+  ignoreAttributes: true,
+  ignoreNameSpace: false,
+  allowBooleanAttributes: false, //a tag can have attributes without any value
+  //ignoreRootElement : false,
+  parseNodeValue: true,
+  parseAttributeValue: false,
+  arrayMode: false,
+  trimValues: true, //Trim string values of tag and attributes
+  cdataTagName: false,
+  cdataPositionChar: '\\c',
+  tagValueProcessor: function(a, tagName) {
+    return a;
+  },
+  attrValueProcessor: function(a, attrName) {
+    return a;
+  },
+  stopNodes: []
+  //decodeStrict: false,
+};
+
+exports.defaultOptions = defaultOptions;
+
+const props = [
+  'attributeNamePrefix',
+  'attrNodeName',
+  'textNodeName',
+  'ignoreAttributes',
+  'ignoreNameSpace',
+  'allowBooleanAttributes',
+  'parseNodeValue',
+  'parseAttributeValue',
+  'arrayMode',
+  'trimValues',
+  'cdataTagName',
+  'cdataPositionChar',
+  'tagValueProcessor',
+  'attrValueProcessor',
+  'parseTrueNumberOnly',
+  'stopNodes'
+];
+exports.props = props;
+
+const getTraversalObj = function(xmlData, options) {
+  options = buildOptions(options, defaultOptions, props);
+  //xmlData = xmlData.replace(/\r?\n/g, " ");//make it single line
+  xmlData = xmlData.replace(/<!--[\s\S]*?-->/g, ''); //Remove  comments
+
+  const xmlObj = new xmlNode('!xml');
+  let currentNode = xmlObj;
+
+  const tagsRegx = new RegExp(regx, 'g');
+  let tag = tagsRegx.exec(xmlData);
+  let nextTag = tagsRegx.exec(xmlData);
+  while (tag) {
+    const tagType = checkForTagType(tag);
+
+    if (tagType === TagType.CLOSING) {
+      //add parsed data to parent node
+      if (currentNode.parent && tag[12]) {
+        currentNode.parent.val = util.getValue(currentNode.parent.val) + '' + processTagValue(tag, options, currentNode.parent.tagname);
+      }
+      if (options.stopNodes.length && options.stopNodes.includes(currentNode.tagname)) {
+        currentNode.child = []
+        if (currentNode.attrsMap == undefined) { currentNode.attrsMap = {}}
+        currentNode.val = xmlData.substr(currentNode.startIndex + 1, tag.index - currentNode.startIndex - 1)
+      }
+      currentNode = currentNode.parent;
+    } else if (tagType === TagType.CDATA) {
+      if (options.cdataTagName) {
+        //add cdata node
+        const childNode = new xmlNode(options.cdataTagName, currentNode, tag[3]);
+        childNode.attrsMap = buildAttributesMap(tag[8], options);
+        currentNode.addChild(childNode);
+        //for backtracking
+        currentNode.val = util.getValue(currentNode.val) + options.cdataPositionChar;
+        //add rest value to parent node
+        if (tag[12]) {
+          currentNode.val += processTagValue(tag, options);
+        }
+      } else {
+        currentNode.val = (currentNode.val || '') + (tag[3] || '') + processTagValue(tag, options);
+      }
+    } else if (tagType === TagType.SELF) {
+      if (currentNode && tag[12]) {
+        currentNode.val = util.getValue(currentNode.val) + '' + processTagValue(tag, options);
+      }
+
+      const childNode = new xmlNode(options.ignoreNameSpace ? tag[7] : tag[5], currentNode, '');
+      if (tag[8] && tag[8].length > 0) {
+        tag[8] = tag[8].substr(0, tag[8].length - 1);
+      }
+      childNode.attrsMap = buildAttributesMap(tag[8], options);
+      currentNode.addChild(childNode);
+    } else {
+      //TagType.OPENING
+      const childNode = new xmlNode(
+        options.ignoreNameSpace ? tag[7] : tag[5],
+        currentNode,
+        processTagValue(tag, options)
+      );
+      if (options.stopNodes.length && options.stopNodes.includes(childNode.tagname)) {
+        childNode.startIndex=tag.index + tag[1].length
+      }
+      childNode.attrsMap = buildAttributesMap(tag[8], options);
+      currentNode.addChild(childNode);
+      currentNode = childNode;
+    }
+
+    tag = nextTag;
+    nextTag = tagsRegx.exec(xmlData);
+  }
+
+  return xmlObj;
+};
+
+function processTagValue(parsedTags, options, parentTagName) {
+  const tagName = parsedTags[7] || parentTagName;
+  let val = parsedTags[12];
+  if (val) {
+    if (options.trimValues) {
+      val = val.trim();
+    }
+    val = options.tagValueProcessor(val, tagName);
+    val = parseValue(val, options.parseNodeValue, options.parseTrueNumberOnly);
+  }
+
+  return val;
+}
+
+function checkForTagType(match) {
+  if (match[4] === ']]>') {
+    return TagType.CDATA;
+  } else if (match[10] === '/') {
+    return TagType.CLOSING;
+  } else if (typeof match[8] !== 'undefined' && match[8].substr(match[8].length - 1) === '/') {
+    return TagType.SELF;
+  } else {
+    return TagType.OPENING;
+  }
+}
+
+function resolveNameSpace(tagname, options) {
+  if (options.ignoreNameSpace) {
+    const tags = tagname.split(':');
+    const prefix = tagname.charAt(0) === '/' ? '/' : '';
+    if (tags[0] === 'xmlns') {
+      return '';
+    }
+    if (tags.length === 2) {
+      tagname = prefix + tags[1];
+    }
+  }
+  return tagname;
+}
+
+function parseValue(val, shouldParse, parseTrueNumberOnly) {
+  if (shouldParse && typeof val === 'string') {
+    let parsed;
+    if (val.trim() === '' || isNaN(val)) {
+      parsed = val === 'true' ? true : val === 'false' ? false : val;
+    } else {
+      if (val.indexOf('0x') !== -1) {
+        //support hexa decimal
+        parsed = Number.parseInt(val, 16);
+      } else if (val.indexOf('.') !== -1) {
+        parsed = Number.parseFloat(val);
+        val = val.replace(/0+$/,"");
+      } else {
+        parsed = Number.parseInt(val, 10);
+      }
+      if (parseTrueNumberOnly) {
+        parsed = String(parsed) === val ? parsed : val;
+      }
+    }
+    return parsed;
+  } else {
+    if (util.isExist(val)) {
+      return val;
+    } else {
+      return '';
+    }
+  }
+}
+
+//TODO: change regex to capture NS
+//const attrsRegx = new RegExp("([\\w\\-\\.\\:]+)\\s*=\\s*(['\"])((.|\n)*?)\\2","gm");
+const attrsRegx = new RegExp('([^\\s=]+)\\s*(=\\s*([\'"])(.*?)\\3)?', 'g');
+
+function buildAttributesMap(attrStr, options) {
+  if (!options.ignoreAttributes && typeof attrStr === 'string') {
+    attrStr = attrStr.replace(/\r?\n/g, ' ');
+    //attrStr = attrStr || attrStr.trim();
+
+    const matches = util.getAllMatches(attrStr, attrsRegx);
+    const len = matches.length; //don't make it inline
+    const attrs = {};
+    for (let i = 0; i < len; i++) {
+      const attrName = resolveNameSpace(matches[i][1], options);
+      if (attrName.length) {
+        if (matches[i][4] !== undefined) {
+          if (options.trimValues) {
+            matches[i][4] = matches[i][4].trim();
+          }
+          matches[i][4] = options.attrValueProcessor(matches[i][4], attrName);
+          attrs[options.attributeNamePrefix + attrName] = parseValue(
+            matches[i][4],
+            options.parseAttributeValue,
+            options.parseTrueNumberOnly
+          );
+        } else if (options.allowBooleanAttributes) {
+          attrs[options.attributeNamePrefix + attrName] = true;
+        }
+      }
+    }
+    if (!Object.keys(attrs).length) {
+      return;
+    }
+    if (options.attrNodeName) {
+      const attrCollection = {};
+      attrCollection[options.attrNodeName] = attrs;
+      return attrCollection;
+    }
+    return attrs;
+  }
+}
+
+exports.getTraversalObj = getTraversalObj;
+
+
+/***/ }),
+
+/***/ 200:
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+"use strict";
+
+//parse Empty Node as self closing node
+const buildOptions = __webpack_require__(343).buildOptions;
+
+const defaultOptions = {
+  attributeNamePrefix: '@_',
+  attrNodeName: false,
+  textNodeName: '#text',
+  ignoreAttributes: true,
+  cdataTagName: false,
+  cdataPositionChar: '\\c',
+  format: false,
+  indentBy: '  ',
+  supressEmptyNode: false,
+  tagValueProcessor: function(a) {
+    return a;
+  },
+  attrValueProcessor: function(a) {
+    return a;
+  },
+};
+
+const props = [
+  'attributeNamePrefix',
+  'attrNodeName',
+  'textNodeName',
+  'ignoreAttributes',
+  'cdataTagName',
+  'cdataPositionChar',
+  'format',
+  'indentBy',
+  'supressEmptyNode',
+  'tagValueProcessor',
+  'attrValueProcessor',
+];
+
+function Parser(options) {
+  this.options = buildOptions(options, defaultOptions, props);
+  if (this.options.ignoreAttributes || this.options.attrNodeName) {
+    this.isAttribute = function(/*a*/) {
+      return false;
+    };
+  } else {
+    this.attrPrefixLen = this.options.attributeNamePrefix.length;
+    this.isAttribute = isAttribute;
+  }
+  if (this.options.cdataTagName) {
+    this.isCDATA = isCDATA;
+  } else {
+    this.isCDATA = function(/*a*/) {
+      return false;
+    };
+  }
+  this.replaceCDATAstr = replaceCDATAstr;
+  this.replaceCDATAarr = replaceCDATAarr;
+
+  if (this.options.format) {
+    this.indentate = indentate;
+    this.tagEndChar = '>\n';
+    this.newLine = '\n';
+  } else {
+    this.indentate = function() {
+      return '';
+    };
+    this.tagEndChar = '>';
+    this.newLine = '';
+  }
+
+  if (this.options.supressEmptyNode) {
+    this.buildTextNode = buildEmptyTextNode;
+    this.buildObjNode = buildEmptyObjNode;
+  } else {
+    this.buildTextNode = buildTextValNode;
+    this.buildObjNode = buildObjectNode;
+  }
+
+  this.buildTextValNode = buildTextValNode;
+  this.buildObjectNode = buildObjectNode;
+}
+
+Parser.prototype.parse = function(jObj) {
+  return this.j2x(jObj, 0).val;
+};
+
+Parser.prototype.j2x = function(jObj, level) {
+  let attrStr = '';
+  let val = '';
+  const keys = Object.keys(jObj);
+  const len = keys.length;
+  for (let i = 0; i < len; i++) {
+    const key = keys[i];
+    if (typeof jObj[key] === 'undefined') {
+      // supress undefined node
+    } else if (jObj[key] === null) {
+      val += this.indentate(level) + '<' + key + '/' + this.tagEndChar;
+    } else if (jObj[key] instanceof Date) {
+      val += this.buildTextNode(jObj[key], key, '', level);
+    } else if (typeof jObj[key] !== 'object') {
+      //premitive type
+      const attr = this.isAttribute(key);
+      if (attr) {
+        attrStr += ' ' + attr + '="' + this.options.attrValueProcessor('' + jObj[key]) + '"';
+      } else if (this.isCDATA(key)) {
+        if (jObj[this.options.textNodeName]) {
+          val += this.replaceCDATAstr(jObj[this.options.textNodeName], jObj[key]);
+        } else {
+          val += this.replaceCDATAstr('', jObj[key]);
+        }
+      } else {
+        //tag value
+        if (key === this.options.textNodeName) {
+          if (jObj[this.options.cdataTagName]) {
+            //value will added while processing cdata
+          } else {
+            val += this.options.tagValueProcessor('' + jObj[key]);
+          }
+        } else {
+          val += this.buildTextNode(jObj[key], key, '', level);
+        }
+      }
+    } else if (Array.isArray(jObj[key])) {
+      //repeated nodes
+      if (this.isCDATA(key)) {
+        val += this.indentate(level);
+        if (jObj[this.options.textNodeName]) {
+          val += this.replaceCDATAarr(jObj[this.options.textNodeName], jObj[key]);
+        } else {
+          val += this.replaceCDATAarr('', jObj[key]);
+        }
+      } else {
+        //nested nodes
+        const arrLen = jObj[key].length;
+        for (let j = 0; j < arrLen; j++) {
+          const item = jObj[key][j];
+          if (typeof item === 'undefined') {
+            // supress undefined node
+          } else if (item === null) {
+            val += this.indentate(level) + '<' + key + '/' + this.tagEndChar;
+          } else if (typeof item === 'object') {
+            const result = this.j2x(item, level + 1);
+            val += this.buildObjNode(result.val, key, result.attrStr, level);
+          } else {
+            val += this.buildTextNode(item, key, '', level);
+          }
+        }
+      }
+    } else {
+      //nested node
+      if (this.options.attrNodeName && key === this.options.attrNodeName) {
+        const Ks = Object.keys(jObj[key]);
+        const L = Ks.length;
+        for (let j = 0; j < L; j++) {
+          attrStr += ' ' + Ks[j] + '="' + this.options.attrValueProcessor('' + jObj[key][Ks[j]]) + '"';
+        }
+      } else {
+        const result = this.j2x(jObj[key], level + 1);
+        val += this.buildObjNode(result.val, key, result.attrStr, level);
+      }
+    }
+  }
+  return {attrStr: attrStr, val: val};
+};
+
+function replaceCDATAstr(str, cdata) {
+  str = this.options.tagValueProcessor('' + str);
+  if (this.options.cdataPositionChar === '' || str === '') {
+    return str + '<![CDATA[' + cdata + ']]' + this.tagEndChar;
+  } else {
+    return str.replace(this.options.cdataPositionChar, '<![CDATA[' + cdata + ']]' + this.tagEndChar);
+  }
+}
+
+function replaceCDATAarr(str, cdata) {
+  str = this.options.tagValueProcessor('' + str);
+  if (this.options.cdataPositionChar === '' || str === '') {
+    return str + '<![CDATA[' + cdata.join(']]><![CDATA[') + ']]' + this.tagEndChar;
+  } else {
+    for (let v in cdata) {
+      str = str.replace(this.options.cdataPositionChar, '<![CDATA[' + cdata[v] + ']]>');
+    }
+    return str + this.newLine;
+  }
+}
+
+function buildObjectNode(val, key, attrStr, level) {
+  if (attrStr && !val.includes('<')) {
+    return (
+      this.indentate(level) +
+      '<' +
+      key +
+      attrStr +
+      '>' +
+      val +
+      //+ this.newLine
+      // + this.indentate(level)
+      '</' +
+      key +
+      this.tagEndChar
+    );
+  } else {
+    return (
+      this.indentate(level) +
+      '<' +
+      key +
+      attrStr +
+      this.tagEndChar +
+      val +
+      //+ this.newLine
+      this.indentate(level) +
+      '</' +
+      key +
+      this.tagEndChar
+    );
+  }
+}
+
+function buildEmptyObjNode(val, key, attrStr, level) {
+  if (val !== '') {
+    return this.buildObjectNode(val, key, attrStr, level);
+  } else {
+    return this.indentate(level) + '<' + key + attrStr + '/' + this.tagEndChar;
+    //+ this.newLine
+  }
+}
+
+function buildTextValNode(val, key, attrStr, level) {
+  return (
+    this.indentate(level) +
+    '<' +
+    key +
+    attrStr +
+    '>' +
+    this.options.tagValueProcessor(val) +
+    '</' +
+    key +
+    this.tagEndChar
+  );
+}
+
+function buildEmptyTextNode(val, key, attrStr, level) {
+  if (val !== '') {
+    return this.buildTextValNode(val, key, attrStr, level);
+  } else {
+    return this.indentate(level) + '<' + key + attrStr + '/' + this.tagEndChar;
+  }
+}
+
+function indentate(level) {
+  return this.options.indentBy.repeat(level);
+}
+
+function isAttribute(name /*, options*/) {
+  if (name.startsWith(this.options.attributeNamePrefix)) {
+    return name.substr(this.attrPrefixLen);
+  } else {
+    return false;
+  }
+}
+
+function isCDATA(name) {
+  return name === this.options.cdataTagName;
+}
+
+//formatting
+//indentation
+//\n after each closing or self closing tag
+
+module.exports = Parser;
+
+
+/***/ }),
+
+/***/ 207:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+
+const util = __webpack_require__(343);
+const buildOptions = __webpack_require__(343).buildOptions;
+const x2j = __webpack_require__(170);
+
+//TODO: do it later
+const convertToJsonString = function(node, options) {
+  options = buildOptions(options, x2j.defaultOptions, x2j.props);
+
+  options.indentBy = options.indentBy || '';
+  return _cToJsonStr(node, options, 0);
+};
+
+const _cToJsonStr = function(node, options, level) {
+  let jObj = '{';
+
+  //traver through all the children
+  const keys = Object.keys(node.child);
+
+  for (let index = 0; index < keys.length; index++) {
+    var tagname = keys[index];
+    if (node.child[tagname] && node.child[tagname].length > 1) {
+      jObj += '"' + tagname + '" : [ ';
+      for (var tag in node.child[tagname]) {
+        jObj += _cToJsonStr(node.child[tagname][tag], options) + ' , ';
+      }
+      jObj = jObj.substr(0, jObj.length - 1) + ' ] '; //remove extra comma in last
+    } else {
+      jObj += '"' + tagname + '" : ' + _cToJsonStr(node.child[tagname][0], options) + ' ,';
+    }
+  }
+  util.merge(jObj, node.attrsMap);
+  //add attrsMap as new children
+  if (util.isEmptyObject(jObj)) {
+    return util.isExist(node.val) ? node.val : '';
+  } else {
+    if (util.isExist(node.val)) {
+      if (!(typeof node.val === 'string' && (node.val === '' || node.val === options.cdataPositionChar))) {
+        jObj += '"' + options.textNodeName + '" : ' + stringval(node.val);
+      }
+    }
+  }
+  //add value
+  if (jObj[jObj.length - 1] === ',') {
+    jObj = jObj.substr(0, jObj.length - 2);
+  }
+  return jObj + '}';
+};
+
+function stringval(v) {
+  if (v === true || v === false || !isNaN(v)) {
+    return v;
+  } else {
+    return '"' + v + '"';
+  }
+}
+
+function indentate(options, level) {
+  return options.indentBy.repeat(level);
+}
+
+exports.convertToJsonString = convertToJsonString;
+
+
+/***/ }),
+
+/***/ 343:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+
+const nameStartChar = ':A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD';
+const nameChar = nameStartChar + '\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040';
+const nameRegexp = '[' + nameStartChar + '][' + nameChar + ']*'
+const regexName = new RegExp('^' + nameRegexp + '$');
+
+const getAllMatches = function(string, regex) {
+  const matches = [];
+  let match = regex.exec(string);
+  while (match) {
+    const allmatches = [];
+    const len = match.length;
+    for (let index = 0; index < len; index++) {
+      allmatches.push(match[index]);
+    }
+    matches.push(allmatches);
+    match = regex.exec(string);
+  }
+  return matches;
+};
+
+const isName = function(string) {
+  const match = regexName.exec(string);
+  return !(match === null || typeof match === 'undefined');
+};
+
+exports.isExist = function(v) {
+  return typeof v !== 'undefined';
+};
+
+exports.isEmptyObject = function(obj) {
+  return Object.keys(obj).length === 0;
+};
+
+/**
+ * Copy all the properties of a into b.
+ * @param {*} target
+ * @param {*} a
+ */
+exports.merge = function(target, a, arrayMode) {
+  if (a) {
+    const keys = Object.keys(a); // will return an array of own properties
+    const len = keys.length; //don't make it inline
+    for (let i = 0; i < len; i++) {
+      if(arrayMode === 'strict'){
+        target[keys[i]] = [ a[keys[i]] ];
+      }else{
+        target[keys[i]] = a[keys[i]];
+      }
+    }
+  }
+};
+/* exports.merge =function (b,a){
+  return Object.assign(b,a);
+} */
+
+exports.getValue = function(v) {
+  if (exports.isExist(v)) {
+    return v;
+  } else {
+    return '';
+  }
+};
+
+// const fakeCall = function(a) {return a;};
+// const fakeCallNoReturn = function() {};
+
+exports.buildOptions = function(options, defaultOptions, props) {
+  var newOptions = {};
+  if (!options) {
+    return defaultOptions; //if there are not options
+  }
+
+  for (let i = 0; i < props.length; i++) {
+    if (options[props[i]] !== undefined) {
+      newOptions[props[i]] = options[props[i]];
+    } else {
+      newOptions[props[i]] = defaultOptions[props[i]];
+    }
+  }
+  return newOptions;
+};
+
+exports.isName = isName;
+exports.getAllMatches = getAllMatches;
+exports.nameRegexp = nameRegexp;
+
 
 /***/ }),
 
@@ -379,11 +1106,16 @@ var __importStar = (this && this.__importStar) || function (mod) {
     result["default"] = mod;
     return result;
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const child_process_1 = __webpack_require__(129);
 const fs = __importStar(__webpack_require__(747));
 const util_1 = __webpack_require__(669);
+const testfailure_1 = __webpack_require__(796);
+const fast_xml_parser_1 = __importDefault(__webpack_require__(989));
 const parsing = __importStar(__webpack_require__(768));
 const asyncExec = util_1.promisify(child_process_1.exec);
 const { GITHUB_WORKSPACE } = process.env;
@@ -396,22 +1128,34 @@ function parseOutput(testFailures) {
             end_line: parsing.parseEndLine(testFailure),
             start_column: 1,
             end_column: 1,
-            annotation_level: 'failure',
+            annotation_level: "failure",
             message: `${testFailure.classname}.${testFailure.name}: ${parsing.parseMessage(testFailure)}`,
         };
     });
 }
+function flatMap(array, callbackfn) {
+    return Array.prototype.concat(...array.map(callbackfn));
+}
+exports.flatMap = flatMap;
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const testResultPath = core.getInput('test_result_path');
+            const testResultPath = core.getInput("test_result_path");
             const outputFilePath = `${GITHUB_WORKSPACE}/${testResultPath}`;
-            if (!fs.existsSync(outputFilePath)) {
-                return;
-            }
-            yield asyncExec(`cat ${outputFilePath} | xq '[.testsuites.testsuite | if type == "array" then .[] else . end | .testcase | if type == "array" then .[] else . end | select(.failure != null) | { classname: ."@classname", name: ."@name", failure: .failure."@message" }]' > ${GITHUB_WORKSPACE}/result.json`);
-            const testResult = yield fs.promises.readFile(`${GITHUB_WORKSPACE}/result.json`);
-            const parsedTestResult = JSON.parse(testResult.toString());
+            const file = yield fs.promises.readFile(outputFilePath);
+            const testResult = fast_xml_parser_1.default.parse(file.toString(), {
+                attributeNamePrefix: "____",
+                ignoreAttributes: false,
+                arrayMode: "strict",
+            });
+            const cases = flatMap(testResult.testsuites, (suite) => flatMap(suite.testsuite, (suite) => suite.testcase));
+            const parsedTestResult = cases
+                .filter((c) => c.failure)
+                .map((c) => {
+                var _a, _b, _c;
+                (_a = c.failure) === null || _a === void 0 ? void 0 : _a[0].____message;
+                return new testfailure_1.TestFailure(c.____classname, c.____name, (_c = (_b = c.failure) === null || _b === void 0 ? void 0 : _b[0].____message) !== null && _c !== void 0 ? _c : "");
+            });
             const annotations = parseOutput(parsedTestResult);
             annotations.forEach(function (annotation) {
                 console.log(`::error file=${annotation.path},line=${annotation.start_line}::${annotation.message}`);
@@ -438,6 +1182,67 @@ module.exports = require("path");
 /***/ (function(module) {
 
 module.exports = require("util");
+
+/***/ }),
+
+/***/ 727:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+
+const util = __webpack_require__(343);
+
+const convertToJson = function(node, options) {
+  const jObj = {};
+
+  //when no child node or attr is present
+  if ((!node.child || util.isEmptyObject(node.child)) && (!node.attrsMap || util.isEmptyObject(node.attrsMap))) {
+    return util.isExist(node.val) ? node.val : '';
+  } else {
+    //otherwise create a textnode if node has some text
+    if (util.isExist(node.val)) {
+      if (!(typeof node.val === 'string' && (node.val === '' || node.val === options.cdataPositionChar))) {
+        if(options.arrayMode === "strict"){
+          jObj[options.textNodeName] = [ node.val ];
+        }else{
+          jObj[options.textNodeName] = node.val;
+        }
+      }
+    }
+  }
+
+  util.merge(jObj, node.attrsMap, options.arrayMode);
+
+  const keys = Object.keys(node.child);
+  for (let index = 0; index < keys.length; index++) {
+    var tagname = keys[index];
+    if (node.child[tagname] && node.child[tagname].length > 1) {
+      jObj[tagname] = [];
+      for (var tag in node.child[tagname]) {
+        jObj[tagname].push(convertToJson(node.child[tagname][tag], options));
+      }
+    } else {
+      if(options.arrayMode === true){
+        const result = convertToJson(node.child[tagname][0], options)
+        if(typeof result === 'object')
+          jObj[tagname] = [ result ];
+        else
+          jObj[tagname] = result;
+      }else if(options.arrayMode === "strict"){
+        jObj[tagname] = [convertToJson(node.child[tagname][0], options) ];
+      }else{
+        jObj[tagname] = convertToJson(node.child[tagname][0], options);
+      }
+    }
+  }
+
+  //add value
+  return jObj;
+};
+
+exports.convertToJson = convertToJson;
+
 
 /***/ }),
 
@@ -478,6 +1283,625 @@ function parseEndLine(testFailure) {
     return matches == null ? 1 : parseInt(matches[1]);
 }
 exports.parseEndLine = parseEndLine;
+
+
+/***/ }),
+
+/***/ 796:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+// {
+//   "classname": "AmountFormatterTests",
+//   "name": "test_shouldFormatToADollarString()",
+//   "failure": "expected to equal <validWithChanges(\"$4,0100\")>, got <validWithChanges(\"$4,010\")>  (/Users/vrutberg/code/qapital-iphone/Modules/ViewSupport/Tests/Tests/TextFieldFormatters/AmountFormatterTests.swift#CharacterRangeLen=0&EndingLineNumber=31&StartingLineNumber=31)"
+// }
+class TestFailure {
+    constructor(classname, name, failure) {
+        this.classname = classname;
+        this.name = name;
+        this.failure = failure;
+    }
+}
+exports.TestFailure = TestFailure;
+
+
+/***/ }),
+
+/***/ 961:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+const char = function(a) {
+  return String.fromCharCode(a);
+};
+
+const chars = {
+  nilChar: char(176),
+  missingChar: char(201),
+  nilPremitive: char(175),
+  missingPremitive: char(200),
+
+  emptyChar: char(178),
+  emptyValue: char(177), //empty Premitive
+
+  boundryChar: char(179),
+
+  objStart: char(198),
+  arrStart: char(204),
+  arrayEnd: char(185),
+};
+
+const charsArr = [
+  chars.nilChar,
+  chars.nilPremitive,
+  chars.missingChar,
+  chars.missingPremitive,
+  chars.boundryChar,
+  chars.emptyChar,
+  chars.emptyValue,
+  chars.arrayEnd,
+  chars.objStart,
+  chars.arrStart,
+];
+
+const _e = function(node, e_schema, options) {
+  if (typeof e_schema === 'string') {
+    //premitive
+    if (node && node[0] && node[0].val !== undefined) {
+      return getValue(node[0].val, e_schema);
+    } else {
+      return getValue(node, e_schema);
+    }
+  } else {
+    const hasValidData = hasData(node);
+    if (hasValidData === true) {
+      let str = '';
+      if (Array.isArray(e_schema)) {
+        //attributes can't be repeated. hence check in children tags only
+        str += chars.arrStart;
+        const itemSchema = e_schema[0];
+        //var itemSchemaType = itemSchema;
+        const arr_len = node.length;
+
+        if (typeof itemSchema === 'string') {
+          for (let arr_i = 0; arr_i < arr_len; arr_i++) {
+            const r = getValue(node[arr_i].val, itemSchema);
+            str = processValue(str, r);
+          }
+        } else {
+          for (let arr_i = 0; arr_i < arr_len; arr_i++) {
+            const r = _e(node[arr_i], itemSchema, options);
+            str = processValue(str, r);
+          }
+        }
+        str += chars.arrayEnd; //indicates that next item is not array item
+      } else {
+        //object
+        str += chars.objStart;
+        const keys = Object.keys(e_schema);
+        if (Array.isArray(node)) {
+          node = node[0];
+        }
+        for (let i in keys) {
+          const key = keys[i];
+          //a property defined in schema can be present either in attrsMap or children tags
+          //options.textNodeName will not present in both maps, take it's value from val
+          //options.attrNodeName will be present in attrsMap
+          let r;
+          if (!options.ignoreAttributes && node.attrsMap && node.attrsMap[key]) {
+            r = _e(node.attrsMap[key], e_schema[key], options);
+          } else if (key === options.textNodeName) {
+            r = _e(node.val, e_schema[key], options);
+          } else {
+            r = _e(node.child[key], e_schema[key], options);
+          }
+          str = processValue(str, r);
+        }
+      }
+      return str;
+    } else {
+      return hasValidData;
+    }
+  }
+};
+
+const getValue = function(a /*, type*/) {
+  switch (a) {
+    case undefined:
+      return chars.missingPremitive;
+    case null:
+      return chars.nilPremitive;
+    case '':
+      return chars.emptyValue;
+    default:
+      return a;
+  }
+};
+
+const processValue = function(str, r) {
+  if (!isAppChar(r[0]) && !isAppChar(str[str.length - 1])) {
+    str += chars.boundryChar;
+  }
+  return str + r;
+};
+
+const isAppChar = function(ch) {
+  return charsArr.indexOf(ch) !== -1;
+};
+
+function hasData(jObj) {
+  if (jObj === undefined) {
+    return chars.missingChar;
+  } else if (jObj === null) {
+    return chars.nilChar;
+  } else if (
+    jObj.child &&
+    Object.keys(jObj.child).length === 0 &&
+    (!jObj.attrsMap || Object.keys(jObj.attrsMap).length === 0)
+  ) {
+    return chars.emptyChar;
+  } else {
+    return true;
+  }
+}
+
+const x2j = __webpack_require__(170);
+const buildOptions = __webpack_require__(343).buildOptions;
+
+const convert2nimn = function(node, e_schema, options) {
+  options = buildOptions(options, x2j.defaultOptions, x2j.props);
+  return _e(node, e_schema, options);
+};
+
+exports.convert2nimn = convert2nimn;
+
+
+/***/ }),
+
+/***/ 971:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+
+const util = __webpack_require__(343);
+
+const defaultOptions = {
+  allowBooleanAttributes: false, //A tag can have attributes without any value
+};
+
+const props = ['allowBooleanAttributes'];
+
+//const tagsPattern = new RegExp("<\\/?([\\w:\\-_\.]+)\\s*\/?>","g");
+exports.validate = function (xmlData, options) {
+  options = util.buildOptions(options, defaultOptions, props);
+
+  //xmlData = xmlData.replace(/(\r\n|\n|\r)/gm,"");//make it single line
+  //xmlData = xmlData.replace(/(^\s*<\?xml.*?\?>)/g,"");//Remove XML starting tag
+  //xmlData = xmlData.replace(/(<!DOCTYPE[\s\w\"\.\/\-\:]+(\[.*\])*\s*>)/g,"");//Remove DOCTYPE
+  const tags = [];
+  let tagFound = false;
+
+  //indicates that the root tag has been closed (aka. depth 0 has been reached)
+  let reachedRoot = false;
+
+  if (xmlData[0] === '\ufeff') {
+    // check for byte order mark (BOM)
+    xmlData = xmlData.substr(1);
+  }
+
+  for (let i = 0; i < xmlData.length; i++) {
+    if (xmlData[i] === '<') {
+      //starting of tag
+      //read until you reach to '>' avoiding any '>' in attribute value
+
+      i++;
+      if (xmlData[i] === '?') {
+        i = readPI(xmlData, ++i);
+        if (i.err) {
+          return i;
+        }
+      } else if (xmlData[i] === '!') {
+        i = readCommentAndCDATA(xmlData, i);
+        continue;
+      } else {
+        let closingTag = false;
+        if (xmlData[i] === '/') {
+          //closing tag
+          closingTag = true;
+          i++;
+        }
+        //read tagname
+        let tagName = '';
+        for (
+          ;
+          i < xmlData.length &&
+          xmlData[i] !== '>' &&
+          xmlData[i] !== ' ' &&
+          xmlData[i] !== '\t' &&
+          xmlData[i] !== '\n' &&
+          xmlData[i] !== '\r';
+          i++
+        ) {
+          tagName += xmlData[i];
+        }
+        tagName = tagName.trim();
+        //console.log(tagName);
+
+        if (tagName[tagName.length - 1] === '/') {
+          //self closing tag without attributes
+          tagName = tagName.substring(0, tagName.length - 1);
+          //continue;
+          i--;
+        }
+        if (!validateTagName(tagName)) {
+          let msg;
+          if(tagName.trim().length === 0) {
+            msg = "There is an unnecessary space between tag name and backward slash '</ ..'.";
+          }else{
+            msg = `Tag '${tagName}' is an invalid name.`;
+          }
+          return getErrorObject('InvalidTag', msg, getLineNumberForPosition(xmlData, i));
+        }
+
+        const result = readAttributeStr(xmlData, i);
+        if (result === false) {
+          return getErrorObject('InvalidAttr', `Attributes for '${tagName}' have open quote.`, getLineNumberForPosition(xmlData, i));
+        }
+        let attrStr = result.value;
+        i = result.index;
+
+        if (attrStr[attrStr.length - 1] === '/') {
+          //self closing tag
+          attrStr = attrStr.substring(0, attrStr.length - 1);
+          const isValid = validateAttributeString(attrStr, options);
+          if (isValid === true) {
+            tagFound = true;
+            //continue; //text may presents after self closing tag
+          } else {
+            //the result from the nested function returns the position of the error within the attribute
+            //in order to get the 'true' error line, we need to calculate the position where the attribute begins (i - attrStr.length) and then add the position within the attribute
+            //this gives us the absolute index in the entire xml, which we can use to find the line at last
+            return getErrorObject(isValid.err.code, isValid.err.msg, getLineNumberForPosition(xmlData, i - attrStr.length + isValid.err.line));
+          }
+        } else if (closingTag) {
+          if (!result.tagClosed) {
+            return getErrorObject('InvalidTag', `Closing tag '${tagName}' doesn't have proper closing.`, getLineNumberForPosition(xmlData, i));
+          } else if (attrStr.trim().length > 0) {
+            return getErrorObject('InvalidTag', `Closing tag '${tagName}' can't have attributes or invalid starting.`, getLineNumberForPosition(xmlData, i));
+          } else {
+            const otg = tags.pop();
+            if (tagName !== otg) {
+              return getErrorObject('InvalidTag', `Closing tag '${otg}' is expected inplace of '${tagName}'.`, getLineNumberForPosition(xmlData, i));
+            }
+
+            //when there are no more tags, we reached the root level.
+            if(tags.length == 0)
+            {
+              reachedRoot = true;
+            }
+          }
+        } else {
+          const isValid = validateAttributeString(attrStr, options);
+          if (isValid !== true) {
+            //the result from the nested function returns the position of the error within the attribute
+            //in order to get the 'true' error line, we need to calculate the position where the attribute begins (i - attrStr.length) and then add the position within the attribute
+            //this gives us the absolute index in the entire xml, which we can use to find the line at last
+            return getErrorObject(isValid.err.code, isValid.err.msg, getLineNumberForPosition(xmlData, i - attrStr.length + isValid.err.line));
+          }
+
+          //if the root level has been reached before ...
+          if(reachedRoot === true) {
+              return getErrorObject('InvalidXml', 'Multiple possible root nodes found.', getLineNumberForPosition(xmlData, i));
+          } else {
+              tags.push(tagName);
+          }
+          tagFound = true;
+        }
+
+        //skip tag text value
+        //It may include comments and CDATA value
+        for (i++; i < xmlData.length; i++) {
+          if (xmlData[i] === '<') {
+            if (xmlData[i + 1] === '!') {
+              //comment or CADATA
+              i++;
+              i = readCommentAndCDATA(xmlData, i);
+              continue;
+            } else {
+              break;
+            }
+          } else if (xmlData[i] === '&') {
+            const afterAmp = validateAmpersand(xmlData, i);
+            if (afterAmp == -1)
+              return getErrorObject('InvalidChar', `char '&' is not expected.`, getLineNumberForPosition(xmlData, i));
+            i = afterAmp;
+          }
+        } //end of reading tag text value
+        if (xmlData[i] === '<') {
+          i--;
+        }
+      }
+    } else {
+      if (xmlData[i] === ' ' || xmlData[i] === '\t' || xmlData[i] === '\n' || xmlData[i] === '\r') {
+        continue;
+      }
+      return getErrorObject('InvalidChar', `char '${xmlData[i]}' is not expected.`, getLineNumberForPosition(xmlData, i));
+    }
+  }
+
+  if (!tagFound) {
+    return getErrorObject('InvalidXml', 'Start tag expected.', 1);
+  } else if (tags.length > 0) {
+    return getErrorObject('InvalidXml', `Invalid '${JSON.stringify(tags, null, 4).replace(/\r?\n/g, '')}' found.`, 1);
+  }
+
+  return true;
+};
+
+/**
+ * Read Processing insstructions and skip
+ * @param {*} xmlData
+ * @param {*} i
+ */
+function readPI(xmlData, i) {
+  var start = i;
+  for (; i < xmlData.length; i++) {
+    if (xmlData[i] == '?' || xmlData[i] == ' ') {
+      //tagname
+      var tagname = xmlData.substr(start, i - start);
+      if (i > 5 && tagname === 'xml') {
+        return getErrorObject('InvalidXml', 'XML declaration allowed only at the start of the document.', getLineNumberForPosition(xmlData, i));
+      } else if (xmlData[i] == '?' && xmlData[i + 1] == '>') {
+        //check if valid attribut string
+        i++;
+        break;
+      } else {
+        continue;
+      }
+    }
+  }
+  return i;
+}
+
+function readCommentAndCDATA(xmlData, i) {
+  if (xmlData.length > i + 5 && xmlData[i + 1] === '-' && xmlData[i + 2] === '-') {
+    //comment
+    for (i += 3; i < xmlData.length; i++) {
+      if (xmlData[i] === '-' && xmlData[i + 1] === '-' && xmlData[i + 2] === '>') {
+        i += 2;
+        break;
+      }
+    }
+  } else if (
+    xmlData.length > i + 8 &&
+    xmlData[i + 1] === 'D' &&
+    xmlData[i + 2] === 'O' &&
+    xmlData[i + 3] === 'C' &&
+    xmlData[i + 4] === 'T' &&
+    xmlData[i + 5] === 'Y' &&
+    xmlData[i + 6] === 'P' &&
+    xmlData[i + 7] === 'E'
+  ) {
+    let angleBracketsCount = 1;
+    for (i += 8; i < xmlData.length; i++) {
+      if (xmlData[i] === '<') {
+        angleBracketsCount++;
+      } else if (xmlData[i] === '>') {
+        angleBracketsCount--;
+        if (angleBracketsCount === 0) {
+          break;
+        }
+      }
+    }
+  } else if (
+    xmlData.length > i + 9 &&
+    xmlData[i + 1] === '[' &&
+    xmlData[i + 2] === 'C' &&
+    xmlData[i + 3] === 'D' &&
+    xmlData[i + 4] === 'A' &&
+    xmlData[i + 5] === 'T' &&
+    xmlData[i + 6] === 'A' &&
+    xmlData[i + 7] === '['
+  ) {
+    for (i += 8; i < xmlData.length; i++) {
+      if (xmlData[i] === ']' && xmlData[i + 1] === ']' && xmlData[i + 2] === '>') {
+        i += 2;
+        break;
+      }
+    }
+  }
+
+  return i;
+}
+
+var doubleQuote = '"';
+var singleQuote = "'";
+
+/**
+ * Keep reading xmlData until '<' is found outside the attribute value.
+ * @param {string} xmlData
+ * @param {number} i
+ */
+function readAttributeStr(xmlData, i) {
+  let attrStr = '';
+  let startChar = '';
+  let tagClosed = false;
+  for (; i < xmlData.length; i++) {
+    if (xmlData[i] === doubleQuote || xmlData[i] === singleQuote) {
+      if (startChar === '') {
+        startChar = xmlData[i];
+      } else if (startChar !== xmlData[i]) {
+        //if vaue is enclosed with double quote then single quotes are allowed inside the value and vice versa
+        continue;
+      } else {
+        startChar = '';
+      }
+    } else if (xmlData[i] === '>') {
+      if (startChar === '') {
+        tagClosed = true;
+        break;
+      }
+    }
+    attrStr += xmlData[i];
+  }
+  if (startChar !== '') {
+    return false;
+  }
+
+  return { value: attrStr, index: i, tagClosed: tagClosed };
+}
+
+/**
+ * Select all the attributes whether valid or invalid.
+ */
+const validAttrStrRegxp = new RegExp('(\\s*)([^\\s=]+)(\\s*=)?(\\s*([\'"])(([\\s\\S])*?)\\5)?', 'g');
+
+//attr, ="sd", a="amit's", a="sd"b="saf", ab  cd=""
+
+function validateAttributeString(attrStr, options) {
+  //console.log("start:"+attrStr+":end");
+
+  //if(attrStr.trim().length === 0) return true; //empty string
+
+  const matches = util.getAllMatches(attrStr, validAttrStrRegxp);
+  const attrNames = {};
+
+  for (let i = 0; i < matches.length; i++) {
+    if (matches[i][1].length === 0) {
+      //nospace before attribute name: a="sd"b="saf"
+      return getErrorObject('InvalidAttr', `Attribute '${matches[i][2]}' has no space in starting.`, getPositionFromMatch(attrStr, matches[i][0]))
+    } else if (matches[i][3] === undefined && !options.allowBooleanAttributes) {
+      //independent attribute: ab
+      return getErrorObject('InvalidAttr', `boolean attribute '${matches[i][2]}' is not allowed.`, getPositionFromMatch(attrStr, matches[i][0]));
+    }
+    /* else if(matches[i][6] === undefined){//attribute without value: ab=
+                    return { err: { code:"InvalidAttr",msg:"attribute " + matches[i][2] + " has no value assigned."}};
+                } */
+    const attrName = matches[i][2];
+    if (!validateAttrName(attrName)) {
+      return getErrorObject('InvalidAttr', `Attribute '${attrName}' is an invalid name.`, getPositionFromMatch(attrStr, matches[i][0]));
+    }
+    if (!attrNames.hasOwnProperty(attrName)) {
+      //check for duplicate attribute.
+      attrNames[attrName] = 1;
+    } else {
+      return getErrorObject('InvalidAttr', `Attribute '${attrName}' is repeated.`, getPositionFromMatch(attrStr, matches[i][0]));
+    }
+  }
+
+  return true;
+}
+
+function validateNumberAmpersand(xmlData, i) {
+  let re = /\d/;
+  if (xmlData[i] === 'x') {
+    i++;
+    re = /[\da-fA-F]/;
+  }
+  for (; i < xmlData.length; i++) {
+    if (xmlData[i] === ';')
+      return i;
+    if (!xmlData[i].match(re))
+      break;
+  }
+  return -1;
+}
+
+function validateAmpersand(xmlData, i) {
+  // https://www.w3.org/TR/xml/#dt-charref
+  i++;
+  if (xmlData[i] === ';')
+    return -1;
+  if (xmlData[i] === '#') {
+    i++;
+    return validateNumberAmpersand(xmlData, i);
+  }
+  let count = 0;
+  for (; i < xmlData.length; i++, count++) {
+    if (xmlData[i].match(/\w/) && count < 20)
+      continue;
+    if (xmlData[i] === ';')
+      break;
+    return -1;
+  }
+  return i;
+}
+
+function getErrorObject(code, message, lineNumber) {
+  return {
+    err: {
+      code: code,
+      msg: message,
+      line: lineNumber,
+    },
+  };
+}
+
+function validateAttrName(attrName) {
+  return util.isName(attrName);
+}
+
+//const startsWithXML = new RegExp("^[Xx][Mm][Ll]");
+//  startsWith = /^([a-zA-Z]|_)[\w.\-_:]*/;
+
+function validateTagName(tagname) {
+  /*if(util.doesMatch(tagname,startsWithXML)) return false;
+    else*/
+  //return !tagname.toLowerCase().startsWith("xml") || !util.doesNotMatch(tagname, regxTagName);
+  return util.isName(tagname);
+}
+
+//this function returns the line number for the character at the given index
+function getLineNumberForPosition(xmlData, index) {
+  var lines = xmlData.substring(0, index).split(/\r?\n/);
+  return lines.length;
+}
+
+//this function returns the position of the last character of match within attrStr
+function getPositionFromMatch(attrStr, match) {
+  return attrStr.indexOf(match) + match.length;
+}
+
+/***/ }),
+
+/***/ 989:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+
+const nodeToJson = __webpack_require__(727);
+const xmlToNodeobj = __webpack_require__(170);
+const x2xmlnode = __webpack_require__(170);
+const buildOptions = __webpack_require__(343).buildOptions;
+const validator = __webpack_require__(971);
+
+exports.parse = function(xmlData, options, validationOption) {
+  if( validationOption){
+    if(validationOption === true) validationOption = {}
+    
+    const result = validator.validate(xmlData, validationOption);
+    if (result !== true) {
+      throw Error( result.err.msg)
+    }
+  }
+  options = buildOptions(options, x2xmlnode.defaultOptions, x2xmlnode.props);
+  return nodeToJson.convertToJson(xmlToNodeobj.getTraversalObj(xmlData, options), options);
+};
+exports.convertTonimn = __webpack_require__(961).convert2nimn;
+exports.getTraversalObj = xmlToNodeobj.getTraversalObj;
+exports.convertToJson = nodeToJson.convertToJson;
+exports.convertToJsonString = __webpack_require__(207).convertToJsonString;
+exports.validate = validator.validate;
+exports.j2xParser = __webpack_require__(200);
+exports.parseToNimn = function(xmlData, schema, options) {
+  return exports.convertTonimn(exports.getTraversalObj(xmlData, options), schema, options);
+};
 
 
 /***/ })

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,11 +15,16 @@ var __importStar = (this && this.__importStar) || function (mod) {
     result["default"] = mod;
     return result;
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const child_process_1 = require("child_process");
 const fs = __importStar(require("fs"));
 const util_1 = require("util");
+const testfailure_1 = require("./testfailure");
+const fast_xml_parser_1 = __importDefault(require("fast-xml-parser"));
 const parsing = __importStar(require("./parsing"));
 const asyncExec = util_1.promisify(child_process_1.exec);
 const { GITHUB_WORKSPACE } = process.env;
@@ -32,22 +37,34 @@ function parseOutput(testFailures) {
             end_line: parsing.parseEndLine(testFailure),
             start_column: 1,
             end_column: 1,
-            annotation_level: 'failure',
+            annotation_level: "failure",
             message: `${testFailure.classname}.${testFailure.name}: ${parsing.parseMessage(testFailure)}`,
         };
     });
 }
+function flatMap(array, callbackfn) {
+    return Array.prototype.concat(...array.map(callbackfn));
+}
+exports.flatMap = flatMap;
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const testResultPath = core.getInput('test_result_path');
+            const testResultPath = core.getInput("test_result_path");
             const outputFilePath = `${GITHUB_WORKSPACE}/${testResultPath}`;
-            if (!fs.existsSync(outputFilePath)) {
-                return;
-            }
-            yield asyncExec(`cat ${outputFilePath} | xq '[.testsuites.testsuite | if type == "array" then .[] else . end | .testcase | if type == "array" then .[] else . end | select(.failure != null) | { classname: ."@classname", name: ."@name", failure: .failure."@message" }]' > ${GITHUB_WORKSPACE}/result.json`);
-            const testResult = yield fs.promises.readFile(`${GITHUB_WORKSPACE}/result.json`);
-            const parsedTestResult = JSON.parse(testResult.toString());
+            const file = yield fs.promises.readFile(outputFilePath);
+            const testResult = fast_xml_parser_1.default.parse(file.toString(), {
+                attributeNamePrefix: "____",
+                ignoreAttributes: false,
+                arrayMode: "strict",
+            });
+            const cases = flatMap(testResult.testsuites, (suite) => flatMap(suite.testsuite, (suite) => suite.testcase));
+            const parsedTestResult = cases
+                .filter((c) => c.failure)
+                .map((c) => {
+                var _a, _b, _c;
+                (_a = c.failure) === null || _a === void 0 ? void 0 : _a[0].____message;
+                return new testfailure_1.TestFailure(c.____classname, c.____name, (_c = (_b = c.failure) === null || _b === void 0 ? void 0 : _b[0].____message) !== null && _c !== void 0 ? _c : "");
+            });
             const annotations = parseOutput(parsedTestResult);
             annotations.forEach(function (annotation) {
                 console.log(`::error file=${annotation.path},line=${annotation.start_line}::${annotation.message}`);

--- a/lib/testfailure.js
+++ b/lib/testfailure.js
@@ -1,2 +1,15 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+// {
+//   "classname": "AmountFormatterTests",
+//   "name": "test_shouldFormatToADollarString()",
+//   "failure": "expected to equal <validWithChanges(\"$4,0100\")>, got <validWithChanges(\"$4,010\")>  (/Users/vrutberg/code/qapital-iphone/Modules/ViewSupport/Tests/Tests/TextFieldFormatters/AmountFormatterTests.swift#CharacterRangeLen=0&EndingLineNumber=31&StartingLineNumber=31)"
+// }
+class TestFailure {
+    constructor(classname, name, failure) {
+        this.classname = classname;
+        this.name = name;
+        this.failure = failure;
+    }
+}
+exports.TestFailure = TestFailure;

--- a/lib/testresult.js
+++ b/lib/testresult.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2499,6 +2499,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.16.0.tgz",
+      "integrity": "sha512-U+bpScacfgnfNfIKlWHDu4u6rtOaCyxhblOLJ8sZPkhsjgGqdZmVPBhdOyvdMGCDt8CsAv+cssOP3NzQptNt2w=="
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@actions/exec": "^1.0.0",
     "@actions/github": "^2.1.1",
     "acorn": ">=5.7.4",
+    "fast-xml-parser": "^3.16.0",
     "minimist": ">=1.2.2"
   },
   "devDependencies": {

--- a/src/testfailure.ts
+++ b/src/testfailure.ts
@@ -3,8 +3,13 @@
 //   "name": "test_shouldFormatToADollarString()",
 //   "failure": "expected to equal <validWithChanges(\"$4,0100\")>, got <validWithChanges(\"$4,010\")>  (/Users/vrutberg/code/qapital-iphone/Modules/ViewSupport/Tests/Tests/TextFieldFormatters/AmountFormatterTests.swift#CharacterRangeLen=0&EndingLineNumber=31&StartingLineNumber=31)"
 // }
-export interface TestFailure {
-    classname: string;
-    name: string;
-    failure: string;
+export class TestFailure {
+  classname: string;
+  name: string;
+  failure: string;
+  constructor(classname: string, name: string, failure: string) {
+    this.classname = classname;
+    this.name = name;
+    this.failure = failure;
+  }
 }

--- a/src/testresult.ts
+++ b/src/testresult.ts
@@ -1,0 +1,23 @@
+export interface TestResult {
+  testsuites: Array<TestSuiteWrapper>;
+}
+
+export interface TestSuiteWrapper {
+  ____name: string;
+  testsuite: Array<TestSuite>;
+}
+
+export interface TestSuite {
+  ____name: string;
+  testcase: Array<TestCase>;
+}
+
+export interface TestCase {
+  ____classname: string;
+  ____name: string;
+  failure?: Failure;
+}
+
+export interface Failure {
+  ____message: string;
+}


### PR DESCRIPTION
## Background 
In an effort to move backend jobs to github actions, we would like to make use of this splendid action. Since our build machines did not have xq installed, we could not run it out-of-the-box.

This should also make it easier to adapt this plugin for new environments
where we do not have xq installed.

## Solution
I added a new dependency on fast-xml-parser to help with the xml parsing.