### PR TITLE
Support reading all result files from a directory

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1106,21 +1106,20 @@ var __importStar = (this && this.__importStar) || function (mod) {
     result["default"] = mod;
     return result;
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const child_process_1 = __webpack_require__(129);
 const fs = __importStar(__webpack_require__(747));
+const path = __importStar(__webpack_require__(622));
 const util_1 = __webpack_require__(669);
 const testfailure_1 = __webpack_require__(796);
-const fast_xml_parser_1 = __importDefault(__webpack_require__(989));
+const xmlParser = __importStar(__webpack_require__(989));
 const parsing = __importStar(__webpack_require__(768));
+const readdir = util_1.promisify(fs.readdir);
 const asyncExec = util_1.promisify(child_process_1.exec);
 const { GITHUB_WORKSPACE } = process.env;
 // Regex match each line in the output and turn them into annotations
-function parseOutput(testFailures) {
+function convertToAnnotations(testFailures) {
     return testFailures.map(function (testFailure) {
         return {
             path: parsing.parsePath(GITHUB_WORKSPACE !== null && GITHUB_WORKSPACE !== void 0 ? GITHUB_WORKSPACE : "", testFailure),
@@ -1136,27 +1135,53 @@ function parseOutput(testFailures) {
 function flatMap(array, callbackfn) {
     return Array.prototype.concat(...array.map(callbackfn));
 }
-exports.flatMap = flatMap;
+function flatten(array) {
+    return flatMap(array, (array) => array);
+}
+function convertBufferToTestFailures(filename) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const buffer = yield fs.promises.readFile(filename);
+        const testResult = xmlParser.parse(buffer.toString(), {
+            attributeNamePrefix: "____",
+            ignoreAttributes: false,
+            arrayMode: "strict",
+        });
+        const cases = flatMap(testResult.testsuites, (suite) => flatMap(suite.testsuite, (suite) => suite.testcase));
+        return cases
+            .filter((c) => c.failure)
+            .map((c) => {
+            var _a, _b, _c;
+            (_a = c.failure) === null || _a === void 0 ? void 0 : _a[0].____message;
+            return new testfailure_1.TestFailure(c.____classname, c.____name, (_c = (_b = c.failure) === null || _b === void 0 ? void 0 : _b[0].____message) !== null && _c !== void 0 ? _c : "");
+        });
+    });
+}
+function parseFileNames(outputFilePath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const directory = fs.lstatSync(outputFilePath).isDirectory();
+        if (directory) {
+            const dir = yield readdir(outputFilePath);
+            return dir
+                .filter((filename) => path.extname(filename) === ".xml")
+                .map((filename) => `${outputFilePath}/${filename}`);
+        }
+        else {
+            return [outputFilePath];
+        }
+    });
+}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const testResultPath = core.getInput("test_result_path");
             const outputFilePath = `${GITHUB_WORKSPACE}/${testResultPath}`;
-            const file = yield fs.promises.readFile(outputFilePath);
-            const testResult = fast_xml_parser_1.default.parse(file.toString(), {
-                attributeNamePrefix: "____",
-                ignoreAttributes: false,
-                arrayMode: "strict",
-            });
-            const cases = flatMap(testResult.testsuites, (suite) => flatMap(suite.testsuite, (suite) => suite.testcase));
-            const parsedTestResult = cases
-                .filter((c) => c.failure)
-                .map((c) => {
-                var _a, _b, _c;
-                (_a = c.failure) === null || _a === void 0 ? void 0 : _a[0].____message;
-                return new testfailure_1.TestFailure(c.____classname, c.____name, (_c = (_b = c.failure) === null || _b === void 0 ? void 0 : _b[0].____message) !== null && _c !== void 0 ? _c : "");
-            });
-            const annotations = parseOutput(parsedTestResult);
+            if (!fs.existsSync(outputFilePath)) {
+                return;
+            }
+            const files = yield parseFileNames(outputFilePath);
+            const testResultPromises = files.map((file) => convertBufferToTestFailures(file));
+            const testResults = flatten(yield Promise.all(testResultPromises));
+            const annotations = convertToAnnotations(testResults);
             annotations.forEach(function (annotation) {
                 console.log(`::error file=${annotation.path},line=${annotation.start_line}::${annotation.message}`);
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,21 +15,20 @@ var __importStar = (this && this.__importStar) || function (mod) {
     result["default"] = mod;
     return result;
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const child_process_1 = require("child_process");
 const fs = __importStar(require("fs"));
+const path = __importStar(require("path"));
 const util_1 = require("util");
 const testfailure_1 = require("./testfailure");
-const fast_xml_parser_1 = __importDefault(require("fast-xml-parser"));
+const xmlParser = __importStar(require("fast-xml-parser"));
 const parsing = __importStar(require("./parsing"));
+const readdir = util_1.promisify(fs.readdir);
 const asyncExec = util_1.promisify(child_process_1.exec);
 const { GITHUB_WORKSPACE } = process.env;
 // Regex match each line in the output and turn them into annotations
-function parseOutput(testFailures) {
+function convertToAnnotations(testFailures) {
     return testFailures.map(function (testFailure) {
         return {
             path: parsing.parsePath(GITHUB_WORKSPACE !== null && GITHUB_WORKSPACE !== void 0 ? GITHUB_WORKSPACE : "", testFailure),
@@ -45,27 +44,53 @@ function parseOutput(testFailures) {
 function flatMap(array, callbackfn) {
     return Array.prototype.concat(...array.map(callbackfn));
 }
-exports.flatMap = flatMap;
+function flatten(array) {
+    return flatMap(array, (array) => array);
+}
+function convertBufferToTestFailures(filename) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const buffer = yield fs.promises.readFile(filename);
+        const testResult = xmlParser.parse(buffer.toString(), {
+            attributeNamePrefix: "____",
+            ignoreAttributes: false,
+            arrayMode: "strict",
+        });
+        const cases = flatMap(testResult.testsuites, (suite) => flatMap(suite.testsuite, (suite) => suite.testcase));
+        return cases
+            .filter((c) => c.failure)
+            .map((c) => {
+            var _a, _b, _c;
+            (_a = c.failure) === null || _a === void 0 ? void 0 : _a[0].____message;
+            return new testfailure_1.TestFailure(c.____classname, c.____name, (_c = (_b = c.failure) === null || _b === void 0 ? void 0 : _b[0].____message) !== null && _c !== void 0 ? _c : "");
+        });
+    });
+}
+function parseFileNames(outputFilePath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const directory = fs.lstatSync(outputFilePath).isDirectory();
+        if (directory) {
+            const dir = yield readdir(outputFilePath);
+            return dir
+                .filter((filename) => path.extname(filename) === ".xml")
+                .map((filename) => `${outputFilePath}/${filename}`);
+        }
+        else {
+            return [outputFilePath];
+        }
+    });
+}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const testResultPath = core.getInput("test_result_path");
             const outputFilePath = `${GITHUB_WORKSPACE}/${testResultPath}`;
-            const file = yield fs.promises.readFile(outputFilePath);
-            const testResult = fast_xml_parser_1.default.parse(file.toString(), {
-                attributeNamePrefix: "____",
-                ignoreAttributes: false,
-                arrayMode: "strict",
-            });
-            const cases = flatMap(testResult.testsuites, (suite) => flatMap(suite.testsuite, (suite) => suite.testcase));
-            const parsedTestResult = cases
-                .filter((c) => c.failure)
-                .map((c) => {
-                var _a, _b, _c;
-                (_a = c.failure) === null || _a === void 0 ? void 0 : _a[0].____message;
-                return new testfailure_1.TestFailure(c.____classname, c.____name, (_c = (_b = c.failure) === null || _b === void 0 ? void 0 : _b[0].____message) !== null && _c !== void 0 ? _c : "");
-            });
-            const annotations = parseOutput(parsedTestResult);
+            if (!fs.existsSync(outputFilePath)) {
+                return;
+            }
+            const files = yield parseFileNames(outputFilePath);
+            const testResultPromises = files.map((file) => convertBufferToTestFailures(file));
+            const testResults = flatten(yield Promise.all(testResultPromises));
+            const annotations = convertToAnnotations(testResults);
             annotations.forEach(function (annotation) {
                 console.log(`::error file=${annotation.path},line=${annotation.start_line}::${annotation.message}`);
             });


### PR DESCRIPTION
## Background
Some tools that generate test results (e.g surefire/failsafe) generate results separated into multiple files. There can for example be one file per test.

## Solution
In order to support this I have added some initial support for having a folder as input.